### PR TITLE
Accept all request methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,21 +141,22 @@ exports.normalizeErrors = function normalizeErrors(errOrErrs) {
  * @api private
  */
 
-exports.detectVerb = function (haystack) {
-	var verbExpr = /^(all|get|post|put|delete|trace|options|connect|patch|head)\s+/i;
-	var verbSpecified = _.last(haystack.match(verbExpr) || []) || '';
-	verbSpecified = verbSpecified.toLowerCase();
+exports.detectVerb = function detectVerb(haystack) {
+  var routeParts = haystack.split(' ');
+  var routeData  = {
+    verb    : '',
+    original: haystack,
+    path    : haystack
+  };
 
-	// If a verb was specified, eliminate the verb from the original string
-	if (verbSpecified) {
-		haystack = haystack.replace(verbExpr,'');
-	}
+  if (routeParts.length === 1) {
+    return routeData;
+  }
 
-	return {
-		verb: verbSpecified,
-		original: haystack,
-		path: haystack
-	};
+  routeData.verb = routeParts.shift();
+  routeData.path = routeParts.join(' ');
+
+  return routeData;
 };
 
 


### PR DESCRIPTION
The request method _doesn't_ matter, as long as it's space separated.

Here's a small test I wrote for the old, and new functions:

``` js
var ld = require('lodash');

function detectVerbNew(haystack) {
  var routeParts = haystack.split(' ');
  var routeData  = {
    verb    : '',
    original: haystack,
    path    : haystack
  };

  if (routeParts.length === 1) {
    return routeData;
  }

  routeData.verb = routeParts.shift();
  routeData.path = routeParts.join(' ');

  return routeData;
}

function detectVerb(haystack) {
  var verbExpr = /^(all|get|post|put|delete|trace|options|connect|patch|head)\s+/i;
  var verbSpecified = ld.last(haystack.match(verbExpr) || []) || '';
  verbSpecified = verbSpecified.toLowerCase();

  // If a verb was specified, eliminate the verb from the original string
  if (verbSpecified) {
    haystack = haystack.replace(verbExpr,'');
  }

  return {
    verb: verbSpecified,
    original: haystack,
    path: haystack
  };
}


detectVerb('get /test/something/:please');
detectVerb('post /test/something/:please');
detectVerb('/test/something/:please');
detectVerb('oops /test/something/:please');
detectVerb('oops /test/something/:please weird');

detectVerbNew('get /test/something/:please');
detectVerbNew('post /test/something/:please');
detectVerbNew('/test/something/:please');
detectVerbNew('oops /test/something/:please');
detectVerbNew('oops /test/something/:please weird');
```

Which outputs:

```
sails> detectVerb('get /test/something/:please');
{ verb: 'get',
  original: '/test/something/:please',
  path: '/test/something/:please' }
sails> detectVerb('post /test/something/:please');
{ verb: 'post',
  original: '/test/something/:please',
  path: '/test/something/:please' }
sails> detectVerb('/test/something/:please');
{ verb: '',
  original: '/test/something/:please',
  path: '/test/something/:please' }
sails> detectVerb('oops /test/something/:please');
{ verb: '',
  original: 'oops /test/something/:please',
  path: 'oops /test/something/:please' }
sails> detectVerb('oops /test/something/:please weird');
{ verb: '',
  original: 'oops /test/something/:please weird',
  path: 'oops /test/something/:please weird' }
sails>
undefined
sails> detectVerbNew('get /test/something/:please');
{ verb: 'get',
  original: 'get /test/something/:please',
  path: '/test/something/:please' }
sails> detectVerbNew('post /test/something/:please');
{ verb: 'post',
  original: 'post /test/something/:please',
  path: '/test/something/:please' }
sails> detectVerbNew('/test/something/:please');
{ verb: '',
  original: '/test/something/:please',
  path: '/test/something/:please' }
sails> detectVerbNew('oops /test/something/:please');
{ verb: 'oops',
  original: 'oops /test/something/:please',
  path: '/test/something/:please' }
sails> detectVerbNew('oops /test/something/:please weird');
{ verb: 'oops',
  original: 'oops /test/something/:please weird',
  path: '/test/something/:please weird' }
```
